### PR TITLE
Fix multibyte charactor encoding error

### DIFF
--- a/fluent-plugin-gcloud-pubsub.gemspec
+++ b/fluent-plugin-gcloud-pubsub.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd"
-  gem.add_runtime_dependency "gcloud", ">= 0.2.0"
+  gem.add_runtime_dependency "fluentd", "~> 0.12.0"
+  gem.add_runtime_dependency "gcloud", "= 0.6.3"
   gem.add_runtime_dependency "fluent-plugin-buffer-lightening", ">= 0.0.2"
 
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
Hi,
gcloud-ruby v0.7.0 to v0.10.0 has multibyte encoding error https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/709 .
And gcloud-ruby before v0.6.2 has issue can't publish messages  https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/713 .

So I think gcloud-ruby v0.6.3 should be used. If v0.10.0 issue is solved, I will pullrequest changing dependency.

Unfortunately, I couldn't work this plugin normally due to behavior of buffer plugin in fluentd v0.14.0 has changed. I added fluentd version dependency.
