### PR TITLE
allow gcloud to autodiscover credentials

### DIFF
--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -26,10 +26,8 @@ module Fluent
     def configure(conf)
       super
 
-      raise Fluent::ConfigError, "'project' must be specified." unless @project
       raise Fluent::ConfigError, "'topic' must be specified." unless @topic
       raise Fluent::ConfigError, "'subscription' must be specified." unless @subscription
-      raise Fluent::ConfigError, "'key' must be specified." unless @key
 
       configure_parser(conf)
     end

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -28,9 +28,7 @@ module Fluent
     def configure(conf)
       super
 
-      raise Fluent::ConfigError, "'project' must be specified." unless @project
       raise Fluent::ConfigError, "'topic' must be specified." unless @topic
-      raise Fluent::ConfigError, "'key' must be specified." unless @key
     end
 
     def start


### PR DESCRIPTION
newer versions of gcloud library are able to use instance credentials automatically

https://googlecloudplatform.github.io/gcloud-ruby/#/docs/v0.10.0/gcloud
