### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0
   - 2.1
   - 2.2.2
+  - 2.3.4
+  - 2.4.1
 
 gemfile:
  - Gemfile

--- a/fluent-plugin-gcloud-pubsub.gemspec
+++ b/fluent-plugin-gcloud-pubsub.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd", "~> 0.12.0"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_runtime_dependency "gcloud", "= 0.6.3"
   gem.add_runtime_dependency "fluent-plugin-buffer-lightening", ">= 0.0.2"
 

--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -21,14 +21,6 @@ module Fluent::Plugin
       config_set_default :@type, 'json'
     end
 
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
     def configure(conf)
       super
 

--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -8,8 +8,8 @@ module Fluent
 
     config_param :tag,                :string
     config_param :project,            :string,  :default => nil
-    config_param :topic,              :string,  :default => nil
-    config_param :subscription,       :string,  :default => nil
+    config_param :topic,              :string
+    config_param :subscription,       :string
     config_param :key,                :string,  :default => nil
     config_param :pull_interval,      :integer, :default => 5
     config_param :max_messages,       :integer, :default => 100
@@ -25,9 +25,6 @@ module Fluent
 
     def configure(conf)
       super
-
-      raise Fluent::ConfigError, "'topic' must be specified." unless @topic
-      raise Fluent::ConfigError, "'subscription' must be specified." unless @subscription
 
       configure_parser(conf)
     end

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -13,7 +13,7 @@ module Fluent
     config_set_default :buffer_queue_limit,         64
 
     config_param :project,            :string,  :default => nil
-    config_param :topic,              :string,  :default => nil
+    config_param :topic,              :string
     config_param :key,                :string,  :default => nil
     config_param :autocreate_topic,   :bool,    :default => false
 
@@ -27,8 +27,6 @@ module Fluent
 
     def configure(conf)
       super
-
-      raise Fluent::ConfigError, "'topic' must be specified." unless @topic
     end
 
     def start

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -25,14 +25,6 @@ module Fluent::Plugin
       config_set_default :queue_limit_length,  64
     end
 
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :buffer)
       super

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -1,21 +1,29 @@
 require 'gcloud'
-require 'fluent/output'
+require 'fluent/plugin/output'
 
-module Fluent
-  class GcloudPubSubOutput < BufferedOutput
+module Fluent::Plugin
+  class GcloudPubSubOutput < Output
     Fluent::Plugin.register_output('gcloud_pubsub', self)
 
-    config_set_default :buffer_type,                'lightening'
-    config_set_default :flush_interval,             1
-    config_set_default :try_flush_interval,         0.05
-    config_set_default :buffer_chunk_records_limit, 900
-    config_set_default :buffer_chunk_limit,         9437184
-    config_set_default :buffer_queue_limit,         64
+    helpers :compat_parameters
+
+    DEFAULT_BUFFER_TYPE = "memory"
 
     config_param :project,            :string,  :default => nil
     config_param :topic,              :string
     config_param :key,                :string,  :default => nil
     config_param :autocreate_topic,   :bool,    :default => false
+
+    config_section :buffer do
+      config_set_default :@type, DEFAULT_BUFFER_TYPE
+      # In v0.14, buffer configurations are renamed.
+      # see: https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/buffer.rb
+      config_set_default :flush_interval,      1
+      config_set_default :try_flush_interval,  0.05
+      config_set_default :chunk_limit_records, 900
+      config_set_default :chunk_limit_size,    9437184
+      config_set_default :queue_limit_length,  64
+    end
 
     unless method_defined?(:log)
       define_method("log") { $log }
@@ -26,6 +34,7 @@ module Fluent
     end
 
     def configure(conf)
+      compat_parameters_convert(conf, :buffer)
       super
     end
 
@@ -38,6 +47,14 @@ module Fluent
 
     def format(tag, time, record)
       [tag, time, record].to_msgpack
+    end
+
+    def formatted_to_msgpack_binary?
+      true
+    end
+
+    def multi_workers_ready?
+      true
     end
 
     def write(chunk)

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -1,5 +1,5 @@
 require_relative "../test_helper"
-
+require 'fluent/test/driver/input'
 
 class GcloudPubSubInputTest < Test::Unit::TestCase
   def setup
@@ -7,7 +7,7 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf=CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::GcloudPubSubInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::GcloudPubSubInput).configure(conf)
   end
 
   def test_configure

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -68,6 +68,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     chunk = d.instance.buffer.generate_chunk(metadata).tap do |c|
       c.append([d.instance.format(tag, time, record)])
     end
+    # For chunk#msgpack_each
     chunk.extend Fluent::ChunkMessagePackEventStreamer
 
     client = Object.new


### PR DESCRIPTION
Please review this PR after merging #17.

I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,